### PR TITLE
Add a before destroy callback to CP's for checking for in progress mappings before removing

### DIFF
--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::MappingsController < ApplicationController
   ###
   def filter
     # Always show only the mappings for the current user's organization
-    mappings = Mapping.where(user: current_user.organization.users)
+    mappings = current_user.organization.mappings
 
     # Filter by current user
     mappings = mappings.where(user: current_user) if params[:filter] != "all"

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -31,6 +31,7 @@ class ConfigurationProfile < ApplicationRecord
 
   def check_ongoing_mappings
     return unless standards_organizations.any? {|dso| dso.mappings.any?(&:in_progress?) }
+
     errors.add(:base, "In progress mappings, unable to remove")
     throw :abort
   end

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -31,7 +31,7 @@ class ConfigurationProfile < ApplicationRecord
   end
 
   def check_ongoing_mappings
-    return unless mappings.any?(&:in_progress?)
+    return unless mappings.in_progress.any?
 
     errors.add(:base, "In progress mappings, unable to remove")
     throw :abort

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -11,6 +11,7 @@ class ConfigurationProfile < ApplicationRecord
   belongs_to :mapping_predicates, class_name: "PredicateSet", foreign_key: :predicate_set_id, optional: true
   belongs_to :administrator, class_name: "User", foreign_key: :administrator_id, optional: true
   has_many :standards_organizations, class_name: "Organization", dependent: :destroy
+  has_many :mappings, through: :standards_organizations
   after_initialize :setup_schema_validators
   before_save :check_structure, if: :incomplete?
   before_destroy :check_ongoing_mappings, prepend: true
@@ -30,7 +31,7 @@ class ConfigurationProfile < ApplicationRecord
   end
 
   def check_ongoing_mappings
-    return unless standards_organizations.any? {|dso| dso.mappings.any?(&:in_progress?) }
+    return unless mappings.any?(&:in_progress?)
 
     errors.add(:base, "In progress mappings, unable to remove")
     throw :abort

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -30,10 +30,9 @@ class ConfigurationProfile < ApplicationRecord
   end
 
   def check_ongoing_mappings
-    if standards_organizations.any? {|dso| dso.mappings.any?(&:in_progress?) }
-      self.errors.add(:base, "In progress mappings, unable to remove")
-      throw :abort
-    end
+    return unless standards_organizations.any? {|dso| dso.mappings.any?(&:in_progress?) }
+    errors.add(:base, "In progress mappings, unable to remove")
+    throw :abort
   end
 
   def check_structure

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -14,11 +14,19 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
+  def agents
+    users.where.not(id: administrator.id)
+  end
+
+  def mappings
+    Mapping.where(user: users)
+  end
+
   def remove_agents
     agents.each(&:destroy!)
   end
 
-  def agents
-    users.where.not(id: administrator.id)
+  def schemes
+    Specification.where(user: users)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,11 +13,5 @@ class Organization < ApplicationRecord
   has_many :schemes, through: :users, source: :specifications
   has_many :vocabularies, dependent: :destroy
 
-  before_destroy :remove_agents
-
   validates :name, presence: true, uniqueness: true
-
-  def remove_agents
-    agents.each(&:destroy!)
-  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,27 +6,18 @@
 class Organization < ApplicationRecord
   belongs_to :administrator, class_name: :User, foreign_key: "administrator_id"
   belongs_to :configuration_profile
+  has_many :agents, ->(o) { where.not(id: o.administrator_id) }, class_name: "User", dependent: :destroy
   has_many :terms, dependent: :destroy
   has_many :users
+  has_many :mappings, through: :users
+  has_many :schemes, through: :users, source: :specifications
   has_many :vocabularies, dependent: :destroy
 
   before_destroy :remove_agents
 
   validates :name, presence: true, uniqueness: true
 
-  def agents
-    users.where.not(id: administrator.id)
-  end
-
-  def mappings
-    Mapping.where(user: users)
-  end
-
   def remove_agents
     agents.each(&:destroy!)
-  end
-
-  def schemes
-    Specification.where(user: users)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :assignments, dependent: :delete_all
   has_many :roles, through: :assignments
   has_many :specifications, dependent: :destroy
+  has_many :mappings, dependent: :destroy
 
   validates :fullname, presence: true
   validates :email, presence: true, uniqueness: true

--- a/spec/mailers/mapping_spec.rb
+++ b/spec/mailers/mapping_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MappingMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.mapping_updated.subject"))
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq([Rails.configuration.action_mailer.default_options[:from]])
+      expect(mail.from).to eq(Rails.configuration.action_mailer.default_options[:from])
     end
 
     it "renders the body" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.welcome.subject"))
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq([Rails.configuration.action_mailer.default_options[:from]])
+      expect(mail.from).to eq(Rails.configuration.action_mailer.default_options[:from])
     end
 
     it "renders the body" do
@@ -25,7 +25,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.forgot_pass.subject"))
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq([Rails.configuration.action_mailer.default_options[:from]])
+      expect(mail.from).to eq(Rails.configuration.action_mailer.default_options[:from])
     end
 
     it "renders the body" do


### PR DESCRIPTION
# Description

- Add logic to ensure that if there's at least one in progress mapping, the Configuration Profile will not be removed.
- Add tests.