### PR TITLE
Make the label "All Changes Saved" to be shown only for 3 seconds

### DIFF
--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import fetchConfigurationProfile from "../../../../services/fetchConfigurationProfile";
 import AlertNotice from "../../../shared/AlertNotice";
@@ -117,22 +117,23 @@ const CPCardHeader = () => {
   const configurationProfile = useSelector((state) => state.currentCP);
   const savingCP = useSelector((state) => state.savingCP);
   const [showChangesSaved, setShowChangesSaved] = useState(false);
-  const triggerLabelShow = () => {
-    setTimeout(() => {
-      setShowChangesSaved(false);
-    }, 3000);
-  };
+
+  const timeoutId = useRef();
 
   useEffect(() => {
     if (savingCP) {
       setShowChangesSaved(true);
-      triggerLabelShow();
 
-      return () => {
-        clearTimeout(triggerLabelShow);
-      };
+      timeoutId.current = setTimeout(() => {
+        setShowChangesSaved(false);
+        timeoutId.current = undefined;
+      }, 3000);
     }
   }, [savingCP]);
+
+  useEffect(() => {
+    return () => timeoutId.current && clearTimeout(timeoutId.current);
+  }, [])
 
   return (
     <Fragment>

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -117,13 +117,20 @@ const CPCardHeader = () => {
   const configurationProfile = useSelector((state) => state.currentCP);
   const savingCP = useSelector((state) => state.savingCP);
   const [showChangesSaved, setShowChangesSaved] = useState(false);
+  const triggerLabelShow = () => {
+    setTimeout(() => {
+      setShowChangesSaved(false);
+    }, 3000);
+  };
 
   useEffect(() => {
     if (savingCP) {
       setShowChangesSaved(true);
-      setTimeout(() => {
-        setShowChangesSaved(false);
-      }, 3000);
+      triggerLabelShow();
+
+      return () => {
+        clearTimeout(triggerLabelShow);
+      };
     }
   }, [savingCP]);
 

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -116,6 +116,16 @@ const EditConfigurationProfile = (props) => {
 const CPCardHeader = () => {
   const configurationProfile = useSelector((state) => state.currentCP);
   const savingCP = useSelector((state) => state.savingCP);
+  const [showChangesSaved, setShowChangesSaved] = useState(false);
+
+  useEffect(() => {
+    if (savingCP) {
+      setShowChangesSaved(true);
+      setTimeout(() => {
+        setShowChangesSaved(false);
+      }, 3000);
+    }
+  }, [savingCP]);
 
   return (
     <Fragment>
@@ -125,9 +135,11 @@ const CPCardHeader = () => {
         </h3>
       </div>
       <div className="col-4">
-        <p className="text-center col-on-primary-light">
-          {savingCP ? "Saving ..." : "All changes saved"}
-        </p>
+        {showChangesSaved && (
+          <p className="text-center col-on-primary-light">
+            {savingCP ? "Saving ..." : "All changes saved"}
+          </p>
+        )}
       </div>
       <div className="col-4">
         <p


### PR DESCRIPTION
# Description
Manage to show this label only for a short period, when the focus gets out from an input of the Configuration Profile
edit screen. This way when a user is typing or changing an input this label is not visible.